### PR TITLE
feat: make param() 's type param `Params` [] by default

### DIFF
--- a/examples/next-swr/src/pages/index.page.tsx
+++ b/examples/next-swr/src/pages/index.page.tsx
@@ -4,7 +4,7 @@ import useSWR from "swr";
 import { apiClient } from "~/src/apiClient";
 
 const Home: NextPage = () => {
-  const args = aspidaToSWR(apiClient.hello, "$get", []).params<[]>((fn) =>
+  const args = aspidaToSWR(apiClient.hello, "$get", []).params((fn) =>
     fn()
   );
   const { data } = useSWR(...args);

--- a/examples/next-swr/src/pages/users/[userId]/index.page.tsx
+++ b/examples/next-swr/src/pages/users/[userId]/index.page.tsx
@@ -11,7 +11,7 @@ const UserDetailPage: NextPage = () => {
     userId !== undefined && apiClient.users._userId(userId),
     "$get",
     []
-  ).params<[]>((fn) => fn());
+  ).params((fn) => fn());
 
   const { data } = useSWR(...args);
 

--- a/src/aspidaToSWR.ts
+++ b/src/aspidaToSWR.ts
@@ -18,7 +18,7 @@ export const aspidaToSWR = <
   method: M,
   extra: OrFalsy<Extra>
 ) => ({
-  params: <Params extends readonly unknown[]>(
+  params: <Params extends readonly unknown[] = []>(
     fetchFn: (fn: T[M], ...rest: [...Extra, ...Params]) => ReturnType<T[M]>
   ): [
     getKey: (...params: Params) => Keys<M, Extra, Params> | null,


### PR DESCRIPTION
If params are always empty, you don't have to specify type params