### PR TITLE
Upgrade swr to 2.0 (adapt to removal of variadic argument's support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 
 This enables [Conditional or Depentent Fetching](https://swr.vercel.app/docs/conditional-fetching) in easy, DRY, and null-safe way.
 
+---
+
+This library doesn't have dependency on SWR.
+
+However, if you use SWR, **we recommend you to use ver 2.x**
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ For example...
 const args = aspidaToSWR(
   userId !== undefined && apiClient.users._userId(userId),
   "$get",
-  isValidToken(token) && ([token] as const)
-).params<[]>((fn, token) => fn( query: { token } ));
+  isValidToken(token) && { token }
+).params((fn, { token }) => fn( query: { token } ));
 
 const { data } = useSWR(...args);
 ```
@@ -59,10 +59,9 @@ const [getKey, fetcher] = aspidaToSWR(
   userId !== undefined &&
     apiClient.users._userId(userId).posts,
   "$get",
-  isValidToken(token) &&
-    ([token] as const)
-).params<[page: number]>(
-  (fn, token, page) => fn({ query: { token, page } })
+  isValidToken(token) && { token }
+).params(
+  (fn, { token }, page: number) => fn({ query: { token, page } })
 );
 
 const { data: pagesData, setSize } = useSWRInfinite(
@@ -80,19 +79,22 @@ Let's take a closer look.
 // token: string | undefined
 
 const [getKey, fetcher] = aspidaToSWR(
-  // api: Api (if falsy, SWR will not start request)
+  // api: Api inferred from value (if falsy, SWR will not start request)
   userId !== undefined &&
     apiClient.users._userId(userId).posts,
   // method: declared method in Api
   "$get",
-  // extra: [string] tuple (if *falsy*, SWR will not start request)
+  // extra: any, inferred from value (if *falsy*, SWR will not start request)
+  // If nothing needed, pass [] or {} (or some *truthy* value) explicitly
+  // , otherwise SWR will not start request.
   isValidToken(token) &&
-    ([token] as const)
-).params<[page: number]>(
+    { token }
+).params( // ).params<[page: number]>( ... inferred from the type annotation.
   // getKey to be (page: number) => keys
-  (fn, token, page) => fn({ query: { token, page } })
+  (fn, { token }, page: number) => fn({ query: { token, page } })
   // tell how to fetch data using 
-  //   extra ([string]) and params ([page: number])
+  // - `extra` ({ token: string }) 
+  // - variadic `...params` (...[page: number])
   // where `fn` is `apiClient.users._userId(userId).posts.$get`
 );
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm i aspida-swr-adapter
 This library has only one API  
 
 ```plaintext
-aspidaToSWR(api, method, extra).params<[p_0: Type, ...]>(callback);
+aspidaToSWR(api, method, extra, (fn, extra, ...params) => ..);
 ```
 
 whose return values `[getKey, fetcher]` (in tuple) are ready to pass to `useSWR`, `useSWRInfinite`, and `useSWRImmutable`.
@@ -41,8 +41,9 @@ For example...
 const args = aspidaToSWR(
   userId !== undefined && apiClient.users._userId(userId),
   "$get",
-  isValidToken(token) && { token }
-).params((fn, { token }) => fn( query: { token } ));
+  isValidToken(token) && { token },
+  (fn, { token }) => fn( query: { token } )
+);
 
 const { data } = useSWR(...args);
 ```
@@ -59,8 +60,7 @@ const [getKey, fetcher] = aspidaToSWR(
   userId !== undefined &&
     apiClient.users._userId(userId).posts,
   "$get",
-  isValidToken(token) && { token }
-).params(
+  isValidToken(token) && { token },
   (fn, { token }, page: number) => fn({ query: { token, page } })
 );
 
@@ -88,14 +88,13 @@ const [getKey, fetcher] = aspidaToSWR(
   // If nothing needed, pass [] or {} (or some *truthy* value) explicitly
   // , otherwise SWR will not start request.
   isValidToken(token) &&
-    { token }
-).params( // ).params<[page: number]>( ... inferred from the type annotation.
-  // getKey to be (page: number) => keys
-  (fn, { token }, page: number) => fn({ query: { token, page } })
-  // tell how to fetch data using 
+    { token },
+  // fetchFn: how to fetch data using 
   // - `extra` ({ token: string }) 
   // - variadic `...params` (...[page: number])
   // where `fn` is `apiClient.users._userId(userId).posts.$get`
+  (fn, { token }, page: number) => fn({ query: { token, page } })
+  // getKey to be (page: number) => keys  ... inferred from the type annotation.
 );
 
 const { data: pagesData, setSize } = useSWRInfinite(

--- a/examples/next-swr/package.json
+++ b/examples/next-swr/package.json
@@ -20,7 +20,7 @@
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "swr": "^1.3.0"
+    "swr": "2"
   },
   "devDependencies": {
     "@types/node": "18.7.2",

--- a/examples/next-swr/src/pages/index.page.tsx
+++ b/examples/next-swr/src/pages/index.page.tsx
@@ -4,9 +4,7 @@ import useSWR from "swr";
 import { apiClient } from "~/src/apiClient";
 
 const Home: NextPage = () => {
-  const args = aspidaToSWR(apiClient.hello, "$get", []).params((fn) =>
-    fn()
-  );
+  const args = aspidaToSWR(apiClient.hello, "$get", [], (fn) => fn());
   const { data } = useSWR(...args);
 
   if (!data) return <div>Loading</div>;

--- a/examples/next-swr/src/pages/users/[userId]/index.page.tsx
+++ b/examples/next-swr/src/pages/users/[userId]/index.page.tsx
@@ -10,8 +10,9 @@ const UserDetailPage: NextPage = () => {
   const args = aspidaToSWR(
     userId !== undefined && apiClient.users._userId(userId),
     "$get",
-    []
-  ).params((fn) => fn());
+    [],
+    (fn) => fn()
+  );
 
   const { data } = useSWR(...args);
 

--- a/examples/next-swr/src/pages/users/[userId]/posts/index.page.tsx
+++ b/examples/next-swr/src/pages/users/[userId]/posts/index.page.tsx
@@ -23,12 +23,11 @@ const UsersIndexPage: NextPage = () => {
     userId !== undefined && // Conditional; fetched only when userId is defined.
       apiClient.users._userId(userId).posts,
     "$get",
-    isValidToken(token) && // Conditional; fetched only when passed `[token]`.
-      ([token] as const)
-  ).params<[page: number]>( // should annotate lazy params explicitly.
-    (fn, token, page) => fn({ query: { token, page } })
-    // `token` is passed in the argument above.
-    // `page` to be passed using `getKey()` function.
+    isValidToken(token) && { token } // Conditional; fetched only when passed `{ token }`.
+  ).params(
+    (fn, { token }, page: number) => fn({ query: { token, page } })
+    // extra arguments (`{ token }`) is passed in the argument above.
+    // `page` should be type-annotated here, so that `getKey()` has `(page: number)` params signature. 
   );
 
   const { data: pagesData, setSize } = useSWRInfinite(

--- a/examples/next-swr/src/pages/users/[userId]/posts/index.page.tsx
+++ b/examples/next-swr/src/pages/users/[userId]/posts/index.page.tsx
@@ -23,11 +23,10 @@ const UsersIndexPage: NextPage = () => {
     userId !== undefined && // Conditional; fetched only when userId is defined.
       apiClient.users._userId(userId).posts,
     "$get",
-    isValidToken(token) && { token } // Conditional; fetched only when passed `{ token }`.
-  ).params(
+    isValidToken(token) && { token }, // Conditional; fetched only when passed `{ token }`.
     (fn, { token }, page: number) => fn({ query: { token, page } })
     // extra arguments (`{ token }`) is passed in the argument above.
-    // `page` should be type-annotated here, so that `getKey()` has `(page: number)` params signature. 
+    // `page` should be type-annotated here, so that `getKey()` has `(page: number)` params signature.
   );
 
   const { data: pagesData, setSize } = useSWRInfinite(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
       npm-run-all: ^4.1.5
       react: 18.2.0
       react-dom: 18.2.0
-      swr: ^1.3.0
+      swr: '2'
       typescript: 4.7.4
     dependencies:
       '@aspida/fetch': 1.10.3
@@ -78,7 +78,7 @@ importers:
       next: 12.2.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      swr: 1.3.0_react@18.2.0
+      swr: 2.0.0_react@18.2.0
     devDependencies:
       '@types/node': 18.7.2
       '@types/react': 18.0.17
@@ -5705,12 +5705,14 @@ packages:
       stable: 0.1.8
     dev: true
 
-  /swr/1.3.0_react@18.2.0:
-    resolution: {integrity: sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==}
+  /swr/2.0.0_react@18.2.0:
+    resolution: {integrity: sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==}
+    engines: {pnpm: '7'}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
   /term-size/2.2.1:

--- a/src/aspidaToSWR.ts
+++ b/src/aspidaToSWR.ts
@@ -13,29 +13,27 @@ type Keys<M, Extra extends {}, Params extends readonly unknown[]> = {
 export const aspidaToSWR = <
   T extends AnyApi,
   M extends MethodOf<T>,
-  Extra extends {}
+  Extra extends {},
+  Params extends readonly unknown[] = []
 >(
   api: OrFalsy<T>,
   method: M,
-  extra: OrFalsy<Extra>
-) => ({
-  params: <Params extends readonly unknown[] = []>(
-    fetchFn: (fn: T[M], extra: Extra, ...rest: [...Params]) => ReturnType<T[M]>
-  ): [
-    getKey: (...params: Params) => Keys<M, Extra, Params> | null,
-    fetcher: (key: Keys<M, Extra, Params>) => ReturnType<typeof fetchFn>
-  ] => [
-    // getKey:
-    (...params) => {
-      return !!api && !!extra
-        ? { path: api.$path(), method, extra, params }
-        : null;
-    },
-    // fetcher:
-    ({ method, extra, params }) => {
-      console.log({ params });
-      if (!!api && !!extra) return fetchFn(api![method], extra, ...params);
-      throw new Error("Unreachable Code");
-    },
-  ],
-});
+  extra: OrFalsy<Extra>,
+  fetchFn: (fn: T[M], extra: Extra, ...rest: [...Params]) => ReturnType<T[M]>
+): [
+  getKey: (...params: Params) => Keys<M, Extra, Params> | null,
+  fetcher: (key: Keys<M, Extra, Params>) => ReturnType<typeof fetchFn>
+] => [
+  // getKey:
+  (...params) => {
+    return !!api && !!extra
+      ? { path: api.$path(), method, extra, params }
+      : null;
+  },
+  // fetcher:
+  ({ method, extra, params }) => {
+    console.log({ params });
+    if (!!api && !!extra) return fetchFn(api![method], extra, ...params);
+    throw new Error("Unreachable Code");
+  },
+];

--- a/src/aspidaToSWR.ts
+++ b/src/aspidaToSWR.ts
@@ -1,38 +1,40 @@
 import { AnyApi, MethodOf } from "./types/aspida";
 import { OrFalsy } from "./types/utils";
 
-type Keys<
-  M,
-  Extra extends readonly unknown[],
-  Params extends readonly unknown[]
-> = [path: string, method: M, ...extra: Extra, ...params: Params];
+type Keys<M, Extra extends {}, Params extends readonly unknown[]> = {
+  path: string;
+  method: M;
+  extra: Extra;
+  params: Params;
+};
 
 /**
  */
 export const aspidaToSWR = <
   T extends AnyApi,
   M extends MethodOf<T>,
-  Extra extends readonly unknown[]
+  Extra extends {}
 >(
   api: OrFalsy<T>,
   method: M,
   extra: OrFalsy<Extra>
 ) => ({
   params: <Params extends readonly unknown[] = []>(
-    fetchFn: (fn: T[M], ...rest: [...Extra, ...Params]) => ReturnType<T[M]>
+    fetchFn: (fn: T[M], extra: Extra, ...rest: [...Params]) => ReturnType<T[M]>
   ): [
     getKey: (...params: Params) => Keys<M, Extra, Params> | null,
-    fetcher: (...args: Keys<M, Extra, Params>) => ReturnType<typeof fetchFn>
+    fetcher: (key: Keys<M, Extra, Params>) => ReturnType<typeof fetchFn>
   ] => [
     // getKey:
     (...params) => {
       return !!api && !!extra
-        ? [api.$path(), method, ...extra, ...params]
+        ? { path: api.$path(), method, extra, params }
         : null;
     },
     // fetcher:
-    (_path, method, ...rest) => {
-      if (!!api && !!rest) return fetchFn(api![method], ...rest);
+    ({ method, extra, params }) => {
+      console.log({ params });
+      if (!!api && !!extra) return fetchFn(api![method], extra, ...params);
       throw new Error("Unreachable Code");
     },
   ],


### PR DESCRIPTION
# BREAKING CHANGE in signature

SWR v2 no longer accepts multiple arguments. 

https://swr.vercel.app/blog/swr-v2#fetcher-no-longer-accepts-multiple-arguments

In addition, by giving up variadic args, type inference became easier.
So, I changed signature of function, to improve developers' experience. (898975d128ce4b33454578ec9c5d2b67004aaf52)